### PR TITLE
refactor: remove unused intervalTypeOptions from duration components …

### DIFF
--- a/src/lib/features/duration/components/duration-widget/next-day-label.tsx
+++ b/src/lib/features/duration/components/duration-widget/next-day-label.tsx
@@ -1,8 +1,4 @@
-import {
-  intervalTypeOptions,
-  RepeatOptionType,
-  TypeOptionType,
-} from "@/schemas/duration";
+import { RepeatOptionType, TypeOptionType } from "@/schemas/duration";
 import {
   addMonths,
   addWeeks,
@@ -85,10 +81,6 @@ export const NextDayLabel = memo(function NextDayLabel({
   date,
 }: NextDayLabelProps) {
   const label = useDurationStore((state) => {
-    const hasCountDownType = intervalTypeOptions.some(
-      (typeOption) => typeOption === type,
-    );
-    if (!hasCountDownType) return getNextDateLabel(date, repeat, type);
     return getNextDateLabel(date, repeat, type, state.now);
   });
 

--- a/src/lib/features/duration/components/duration-widget/time-difference-label.tsx
+++ b/src/lib/features/duration/components/duration-widget/time-difference-label.tsx
@@ -1,4 +1,4 @@
-import { intervalTypeOptions, TypeOptionType } from "@/schemas/duration";
+import { TypeOptionType } from "@/schemas/duration";
 import {
   differenceInYears,
   format,
@@ -40,10 +40,6 @@ export const TimeDifferenceLabel = memo(function TimeDifferenceLabel({
   type,
 }: TimeDifferenceLabelProps) {
   const todayString = useDurationStore((state) => {
-    const hasCountDownType = intervalTypeOptions.some(
-      (typeOption) => typeOption === type,
-    );
-    if (!hasCountDownType) return undefined;
     return format(state.now, "yyyy-MM-dd");
   });
 

--- a/src/schemas/duration.ts
+++ b/src/schemas/duration.ts
@@ -37,9 +37,3 @@ export type DurationFormValues = z.infer<typeof durationFormSchema>;
 
 export type TypeOptionType = "none" | "anniversary" | "birthday" | "bills";
 export type RepeatOptionType = "week" | "month" | "year" | "none";
-export type IntervalType = "anniversary" | "birthday" | "bills";
-export const intervalTypeOptions: IntervalType[] = [
-  "anniversary",
-  "birthday",
-  "bills",
-] as const;


### PR DESCRIPTION
…to support the date count down

## Description

1. remove unused intervalTypeOptions from duration components
2. Support the next day count down 

## Related Issues



## Pre-launch Checklist

- [x] I have tested this change locally.
- [x] I have formatted this code with correctly.
- [x] I have added tests to cover my changes.
- [x] I have updated the documentation if necessary.
